### PR TITLE
Add allowed actions

### DIFF
--- a/code/GridFieldExpandableForm.php
+++ b/code/GridFieldExpandableForm.php
@@ -46,7 +46,8 @@ class GridFieldExpandableForm_ItemRequest extends RequestHandler {
 	private static $allowed_actions = array(
 		'edit',
 		'view',
-		'ItemEditForm'
+		'ItemEditForm',
+		'ExpandableForm'
 	);
 
 	static $url_handlers = array(


### PR DESCRIPTION
In 3.1 the allowed actions array is mandatory. The plugin breaks without it.
