### PR TITLE
Correct js paths

### DIFF
--- a/code/GridFieldExpandableForm.php
+++ b/code/GridFieldExpandableForm.php
@@ -30,8 +30,8 @@ class GridFieldExpandableForm implements GridField_URLHandler, GridField_HTMLPro
 	public function getHTMLFragments($gridField) {
 
 		Requirements::javascript(FRAMEWORK_DIR . '/thirdparty/jquery-ui/jquery-ui.js');
-		Requirements::javascript('GridFieldAddOns/javascript/GridFieldExpandableForm.js');
-		Requirements::css('GridFieldAddOns/css/GridFieldExpandableForm.css');
+		Requirements::javascript('gridfield-addons/javascript/GridFieldExpandableForm.js');
+		Requirements::css('gridfield-addons/css/GridFieldExpandableForm.css');
 
 		$gridField->addExtraClass('expandable-forms');
 		$gridField->setAttribute('data-pseudo-form-url', $gridField->Link('expand'));


### PR DESCRIPTION
The js paths are wrong for when the module is installed with Composer.
This fixes Composer installs but might break direct downloads.
