### PR TITLE
Ensure module folder is named "GridFieldAddOns"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 		},
 	"extra":
 		{
+			"installer-name": "GridFieldAddOns",
 			"snapshot" : "https://raw.github.com/smindel/silverstripe-GridFieldAddOns/master/docs/en/_images/GridFieldEditableCells1.png"
 		},
 	"support": {


### PR DESCRIPTION
js-requirements require the module folder to be named "GridFieldAddOns"