### PR TITLE
FIX: Don't assume SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	"require": 
 		{
 			"php": ">=5.3.2",
-			"silverstripe/framework": ">=3.0.1"
+			"silverstripe/framework": "^3.0.1"
 		},
 	"extra":
 		{


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS4.

This will also ensure that addons.silverstripe.org correctly reports which modules
work with SS4.